### PR TITLE
Miscellaneous formatting and style changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,19 +6,17 @@ version = "0.1.0"
 keywords = ["pipewire", "graph", "editor", "audio", "patchbay"]
 categories = ["multimedia::audio", "visualization", "gui"]
 
-
 repository = "https://github.com/Ax9D/pw-viz"
 readme = "README.md"
 license = "GPL-3.0-only"
 
 edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 pipewire = "0.4.1"
 rand = "0.8.4"
 log = {version = "0.4.14", features = ["release_max_level_warn"] }
-simple_logger="1.13.0"
+simple_logger = "1.13.0"
 
 # egui stuff
 eframe = { version = "0.15.0", features = ["persistence"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,15 +9,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("Failed to init logger");
     }
 
-    //The Ui (main thread) and PipeWire client run on different threads, communication between the threads is facilitated using message passing
-
+    // The UI (main thread) and PipeWire client run on different threads, communication between the threads is facilitated using message passing
     let (sender, receiver) = std::sync::mpsc::channel();
     let (pwsender, pwreciever) = pipewire::channel::channel();
 
-    //Set's up pipewire thread
+    // Set up pipewire thread
     let pw_thread_handle = thread::spawn(move || {
         let sender = Rc::new(sender);
-
         pipewire_impl::thread_main(sender, pwreciever).expect("Failed to init pipewire client");
     });
 

--- a/src/pipewire_impl/state.rs
+++ b/src/pipewire_impl/state.rs
@@ -5,8 +5,9 @@ pub enum GlobalObject {
     Link,
     Port { node_id: u32, id: u32 },
 }
-///For internal state tracking, this has to be done because pipewire only provides ids of the objects it removes,
-///which is insufficient to safely remove an object of a particular type, hence this struct serves as a lookup from id to object specific info
+
+/// For internal state tracking, this has to be done because pipewire only provides ids of the objects it removes,
+/// which is insufficient to safely remove an object of a particular type, hence this struct serves as a lookup from id to object specific info
 pub struct State {
     objects: HashMap<u32, GlobalObject>,
 }

--- a/src/ui/graph.rs
+++ b/src/ui/graph.rs
@@ -1,57 +1,51 @@
-use std::collections::{HashMap, HashSet};
-
 use egui::Widget;
 use egui_nodes::{LinkArgs, NodeArgs, NodeConstructor, PinArgs};
-
-use crate::pipewire_impl::MediaType;
+use std::collections::{HashMap, HashSet};
 
 use super::{link::Link, node::Node, Theme};
+use crate::pipewire_impl::MediaType;
 
-///Represents changes to any links that might happend in the ui
-///These changes are used to send updates to the pipewire thread
+/// Represents changes to any links that might happend in the ui
+/// These changes are used to send updates to the pipewire thread
 pub enum LinkUpdate {
     Created {
         from_port: u32,
         to_port: u32,
-
         from_node: u32,
         to_node: u32,
     },
-
     Removed(u32),
 }
+
 pub struct Graph {
     nodes_ctx: egui_nodes::Context,
-    nodes: HashMap<u32, Node>, //Node id to Node
-    links: HashMap<u32, Link>, //Link id to Link
+    nodes: HashMap<u32, Node>, // Node id to Node
+    links: HashMap<u32, Link>, // Link id to Link
 }
 
 impl Graph {
     pub fn new() -> Self {
-        //context.attribute_flag_push(egui_nodes::AttributeFlags::EnableLinkCreationOnSnap);
-        //context.attribute_flag_push(egui_nodes::AttributeFlags::EnableLinkDetachWithDragClick);
         Self {
             nodes_ctx: egui_nodes::Context::default(),
-
             nodes: HashMap::new(),
             links: HashMap::new(),
         }
     }
-    pub fn add_node(&mut self, node: Node) {
-        log::debug!("New node: {}", node.name());
 
-        self.nodes.insert(node.id(), node);
+    pub fn add_node(&mut self, node: Node) {
+        log::debug!("New node: {}", node.name);
+        self.nodes.insert(node.id, node);
     }
+
     pub fn remove_node(&mut self, id: u32) -> Option<Node> {
         let removed = self.nodes.remove(&id);
-
-        match &removed {
-            Some(node) => log::debug!("Removed node: {}", node.name()),
+        match removed {
+            Some(ref node) => log::debug!("Removed node: {}", node.name),
             None => log::warn!("Node with id {} doesn't exist", id),
         }
-
         removed
     }
+
     #[allow(dead_code)]
     pub fn get_node(&self, id: u32) -> Option<&Node> {
         self.nodes.get(&id)
@@ -59,11 +53,7 @@ impl Graph {
     pub fn get_node_mut(&mut self, id: u32) -> Option<&mut Node> {
         self.nodes.get_mut(&id)
     }
-    pub fn add_link(&mut self, link: Link) {
-        log::debug!("{}->{}", link.from_port, link.to_port);
 
-        self.links.insert(link.id, link);
-    }
     #[allow(dead_code)]
     pub fn get_link(&self, id: u32) -> Option<&Link> {
         self.links.get(&id)
@@ -72,23 +62,25 @@ impl Graph {
     pub fn get_link_mut(&mut self, id: u32) -> Option<&mut Link> {
         self.links.get_mut(&id)
     }
+
+    pub fn add_link(&mut self, link: Link) {
+        log::debug!("{}->{}", link.from_port, link.to_port);
+        self.links.insert(link.id, link);
+    }
     pub fn remove_link(&mut self, id: u32) -> Option<Link> {
         let removed = self.links.remove(&id);
-
-        match &removed {
-            Some(link) => {
-                log::debug!("{}-x-{}", link.from_port, link.to_port);
-            }
+        match removed {
+            Some(ref link) => log::debug!("{}-x-{}", link.from_port, link.to_port),
             None => log::warn!("Link with id {} doesn't exist", id),
         }
-
         removed
     }
-    ///Naive, inefficient and weird implementation of Kahn's algorithm
-    fn topo_sort(&self) -> Vec<u32> {
-        //FIX ME
 
-        //Node id to in-degree(no. of nodes that output to this node)
+    /// Naive, inefficient and weird implementation of Kahn's algorithm
+    fn topo_sort(&self) -> Vec<u32> {
+        // FIX ME
+
+        // Node id to in-degree(no. of nodes that output to this node)
         let mut indegrees = self
             .nodes
             .keys()
@@ -104,7 +96,7 @@ impl Graph {
             })
             .collect::<HashMap<u32, usize>>();
 
-        //Adjacency hashmap, maps node id to neighbouring node ids
+        // Adjacency hashmap, maps node id to neighbouring node ids
         let adj_list = self
             .nodes
             .keys()
@@ -119,75 +111,69 @@ impl Graph {
             })
             .collect::<HashMap<u32, _>>();
 
-        //println!("Indegrees {:?}", indegrees);
-        //println!("Adj list {:?}", self.adj_list);
+        // println!("Indegrees {:?}", indegrees);
+        // println!("Adj list {:?}", self.adj_list);
 
         let mut queue: Vec<u32> = Vec::new();
 
         for node_id in self.nodes.keys() {
-            //Put nodes which are "detached"(i.e of in-degree=0) from the graph into the queue for processing
+            // Put nodes which are "detached"(i.e of in-degree=0) from the graph into the queue for processing
             if indegrees[node_id] == 0 {
                 queue.push(*node_id);
             }
         }
 
         let mut top_order = Vec::new();
-
         let mut count = 0;
         while !queue.is_empty() {
-            //println!("Queue: {:?}", queue);
-            let u = queue.remove(0); //Remove from the front of the queue
-
+            // println!("Queue: {:?}", queue);
+            let u = queue.remove(0); // Remove from the front of the queue
             top_order.push(u);
-
             if let Some(adj_nodes) = adj_list.get(&u) {
-                //Check nodes that lead out from this node
+                // Check nodes that lead out from this node
                 for node_id in adj_nodes {
-                    //Remove link from parent node to this node
+                    // Remove link from parent node to this node
                     let indegree_of_node = indegrees.get_mut(node_id).unwrap();
                     *indegree_of_node -= 1;
 
-                    //Check if that detached the node from the graph
+                    // Check if that detached the node from the graph
                     if *indegree_of_node == 0 {
-                        //If it did, we have a new detached node to process
+                        // If it did, we have a new detached node to process
                         queue.push(*node_id);
                     }
                 }
             }
-
             count += 1;
         }
 
         if count != self.nodes.len() {
             log::error!("Cycle detected");
         }
-
         top_order
     }
+
     pub fn draw(
         &mut self,
         ctx: &egui::CtxRef,
         ui: &mut egui::Ui,
         theme: &Theme,
     ) -> Option<LinkUpdate> {
-        //Find the topologically sorted order of nodes in the graph
-        //Nodes are currently laid out based on this order
+        // Find the topologically sorted order of nodes in the graph
+        // Nodes are currently laid out based on this order
         let order = self.topo_sort();
 
-        //println!("{:?}", order);
+        // println!("{:?}", order);
 
-        //Ctrl is used to trigger the debug view
+        // Ctrl is used to trigger the debug view
         let debug_view = ctx.input().modifiers.ctrl;
-
         let mut ui_nodes = Vec::with_capacity(self.nodes.len());
-
         let mut prev_pos = egui::pos2(ui.available_width() / 4.0, ui.available_height() / 2.0);
         let mut padding = egui::pos2(75.0, 150.0);
         for node_id in order {
             let node = self.nodes.get_mut(&node_id).unwrap();
 
             let mut ui_node = NodeConstructor::new(
-                node.id() as usize,
+                node.id as usize,
                 NodeArgs {
                     titlebar: Some(theme.titlebar),
                     titlebar_hovered: Some(theme.titlebar_hovered),
@@ -197,13 +183,17 @@ impl Graph {
             );
 
             // if node.position.is_none() {
-
-            //     //Horizontally shift each node to the right of the previous one
-            //     //Also put it at a random point vertically
-            //     ui_node.with_origin(egui::pos2(pos.x + padding, rand::random::<f32>() * ui.available_height()));
-
+            //     // Horizontally shift each node to the right of the previous one
+            //     // Also put it at a random point vertically
+            //     ui_node.with_origin(egui::pos2(
+            //         prev_pos.x + padding.x,
+            //         rand::random::<f32>() * ui.available_height(),
+            //     ));
             // } else {
-            //     ui_node.with_origin(egui::pos2(ui.available_width() / 4.0, rand::random::<f32>() * ui.available_height()));
+            //     ui_node.with_origin(egui::pos2(
+            //         ui.available_width() / 4.0,
+            //         rand::random::<f32>() * ui.available_height(),
+            //     ));
             // }
 
             let node_position = node.position.unwrap_or_else(|| {
@@ -214,8 +204,7 @@ impl Graph {
 
             prev_pos = node_position;
 
-            let media_type = node.media_type();
-            let kind = match media_type {
+            let kind = match node.media_type {
                 Some(MediaType::Audio) => "🔉",
                 Some(MediaType::Video) => "💻",
                 Some(MediaType::Midi) => "🎹",
@@ -224,16 +213,15 @@ impl Graph {
 
             let title = {
                 if debug_view {
-                    format!("{}[{}]{}", node.name(), node.id(), kind) //Display node id if in debug view
+                    // Display node id if in debug view
+                    format!("{}[{}]{}", node.name, node.id, kind)
                 } else {
-                    format!("{} {}", node.name(), kind)
+                    format!("{} {}", node.name, kind)
                 }
             };
 
             ui_node.with_title(|ui| egui::Label::new(title).text_color(theme.text_color).ui(ui));
-
             Self::draw_ports(&mut ui_node, node, theme, debug_view);
-
             ui_nodes.push(ui_node);
         }
 
@@ -265,129 +253,25 @@ impl Graph {
                 to_node
             );
 
-            let from_port = from_port as u32;
-            let to_port = to_port as u32;
-
-            let from_node = from_node as u32;
-            let to_node = to_node as u32;
-
             Some(LinkUpdate::Created {
-                from_port,
-                to_port,
-
-                from_node,
-                to_node,
+                from_port: from_port as u32,
+                to_port: to_port as u32,
+                from_node: from_node as u32,
+                to_node: to_node as u32,
             })
         } else {
             None
         }
     }
 
-    // pub fn draw_old(
-    //     &mut self,
-    //     ctx: &egui::CtxRef,
-    //     nodes_ctx: &mut egui_nodes::Context,
-    //     ui: &mut egui::Ui,
-    //     theme: &Theme,
-    // ) -> Option<LinkUpdate> {
-    //     let debug = cfg!(debug_assertions) && ctx.input().modifiers.ctrl;
-
-    //     let ui_nodes = self
-    //         .nodes
-    //         .values_mut()
-    //         .map(|node| {
-    //             let mut ui_node = NodeConstructor::new(
-    //                 node.id() as usize,
-    //                 NodeArgs {
-    //                     titlebar: Some(theme.titlebar),
-    //                     titlebar_hovered: Some(theme.titlebar_hovered),
-    //                     titlebar_selected: Some(theme.titlebar_hovered),
-    //                     ..Default::default()
-    //                 },
-    //             );
-
-    //             if node.newly_added {
-    //                 ui_node.with_origin(egui::pos2(
-    //                     rand::random::<f32>() * ui.available_height(),
-    //                     rand::random::<f32>() * ui.available_height(),
-    //                 ));
-    //                 node.newly_added = false;
-    //             }
-
-    //             let media_type = node.media_type();
-    //             let kind = match media_type {
-    //                 Some(MediaType::Audio) => "🔉",
-    //                 Some(MediaType::Video) => "💻",
-    //                 Some(MediaType::Midi) => "🎹",
-    //                 None => "",
-    //             };
-
-    //             let title = {
-    //                 if debug {
-    //                     format!("{}[{}]{}", node.name(), node.id(), kind)
-    //                 } else {
-    //                     format!("{} {}", node.name(), kind)
-    //                 }
-    //             };
-
-    //             ui_node
-    //                 .with_title(|ui| egui::Label::new(title).text_color(theme.text_color).ui(ui));
-
-    //             Self::draw_ports(&mut ui_node, node, theme, debug);
-
-    //             ui_node
-    //         })
-    //         .collect::<Vec<_>>();
-
-    //     let links = self.links.values().map(|link| {
-    //         (
-    //             link.id as usize,
-    //             link.from_port as usize,
-    //             link.to_port as usize,
-    //             LinkArgs::default(),
-    //         )
-    //     });
-
-    //     nodes_ctx.show(ui_nodes, links, ui);
-
-    //     if let Some(link) = nodes_ctx.link_destroyed() {
-    //         Some(LinkUpdate::Removed(link as u32))
-    //     } else if let Some((from_port, from_node, to_port, to_node, _)) =
-    //         nodes_ctx.link_created_node()
-    //     {
-    //         log::debug!(
-    //             "Created new link:\nfrom_port {}, to_port {}, from_node {}, to_node {}",
-    //             from_port,
-    //             to_port,
-    //             from_node,
-    //             to_node
-    //         );
-
-    //         let from_port = from_port as u32;
-    //         let to_port = to_port as u32;
-
-    //         let from_node = from_node as u32;
-    //         let to_node = to_node as u32;
-
-    //         Some(LinkUpdate::Created {
-    //             from_port,
-    //             to_port,
-
-    //             from_node,
-    //             to_node,
-    //         })
-    //     } else {
-    //         None
-    //     }
-    // }
     fn draw_ports(ui_node: &mut NodeConstructor, node: &Node, theme: &Theme, debug: bool) {
-        let mut ports = node.ports().values().collect::<Vec<_>>();
+        let mut ports = node.ports.values().collect::<Vec<_>>();
 
-        //Sorts ports based on alphabetical ordering
-        ports.sort_by(|a, b| a.name().cmp(b.name()));
+        // Sorts ports based on alphabetical ordering
+        ports.sort_by(|a, b| a.name.cmp(&b.name));
 
         for port in ports {
-            let (background, hovered) = match node.media_type() {
+            let (background, hovered) = match node.media_type {
                 Some(MediaType::Audio) => (theme.audio_port, theme.audio_port_hovered),
                 Some(MediaType::Video) => (theme.video_port, theme.video_port_hovered),
                 Some(MediaType::Midi) => (egui::Color32::RED, egui::Color32::LIGHT_RED),
@@ -395,16 +279,16 @@ impl Graph {
             };
             let port_name = {
                 if debug {
-                    format!("{} [{}]", port.name(), port.id())
+                    format!("{} [{}]", port.name, port.id)
                 } else {
-                    format!("{} ", port.name())
+                    format!("{} ", port.name)
                 }
             };
 
-            match port.port_type() {
+            match port.port_type {
                 crate::pipewire_impl::PortType::Input => {
                     ui_node.with_input_attribute(
-                        port.id() as usize,
+                        port.id as usize,
                         PinArgs {
                             background: Some(background),
                             hovered: Some(hovered),
@@ -419,7 +303,7 @@ impl Graph {
                 }
                 crate::pipewire_impl::PortType::Output => {
                     ui_node.with_output_attribute(
-                        port.id() as usize,
+                        port.id as usize,
                         PinArgs {
                             background: Some(background),
                             hovered: Some(hovered),

--- a/src/ui/link.rs
+++ b/src/ui/link.rs
@@ -3,7 +3,6 @@ pub struct Link {
     pub id: u32,
     pub from_node: u32,
     pub to_node: u32,
-
     pub from_port: u32,
     pub to_port: u32,
     pub active: bool,

--- a/src/ui/node.rs
+++ b/src/ui/node.rs
@@ -1,16 +1,15 @@
 use std::collections::HashMap;
 
-use crate::pipewire_impl::MediaType;
-
 use super::port::Port;
+use crate::pipewire_impl::MediaType;
 
 #[derive(Debug)]
 pub struct Node {
-    id: u32,
-    name: String,
-    media_type: Option<MediaType>,
-    ports: HashMap<u32, Port>, //Port id to Port
-    pub(super) position: Option<egui::Pos2>,
+    pub id: u32,
+    pub name: String,
+    pub media_type: Option<MediaType>,
+    pub ports: HashMap<u32, Port>, // Port id to Port
+    pub position: Option<egui::Pos2>,
 }
 
 impl Node {
@@ -23,23 +22,11 @@ impl Node {
             position: None,
         }
     }
+
     pub fn add_port(&mut self, port: Port) {
-        self.ports.insert(port.id(), port);
+        self.ports.insert(port.id, port);
     }
     pub fn remove_port(&mut self, port_id: u32) {
         self.ports.remove(&port_id);
-    }
-
-    pub fn id(&self) -> u32 {
-        self.id
-    }
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-    pub fn media_type(&self) -> Option<MediaType> {
-        self.media_type
-    }
-    pub fn ports(&self) -> &HashMap<u32, Port> {
-        &self.ports
     }
 }

--- a/src/ui/port.rs
+++ b/src/ui/port.rs
@@ -2,25 +2,7 @@ use crate::pipewire_impl::PortType;
 
 #[derive(Debug)]
 pub struct Port {
-    id: u32,
-    name: String,
-    port_type: PortType,
-}
-impl Port {
-    pub fn new(id: u32, name: String, port_type: PortType) -> Self {
-        Self {
-            id,
-            name,
-            port_type,
-        }
-    }
-    pub fn id(&self) -> u32 {
-        self.id
-    }
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-    pub fn port_type(&self) -> PortType {
-        self.port_type
-    }
+    pub id: u32,
+    pub name: String,
+    pub port_type: PortType,
 }


### PR DESCRIPTION
Sorry for the low-hanging fruit PR. Went through and cleaned up formatting and some small code layout issues. No major business logic changes. Moved `Node`, `Link`, and `Port` definitions into `graph.rs` after pruning some unnecessary methods (like field getters). Didn't touch the topological sort implementation.