### PR TITLE
Basic implementation for interaction hints

### DIFF
--- a/src/ui/graph.rs
+++ b/src/ui/graph.rs
@@ -235,6 +235,14 @@ impl Graph {
         });
 
         self.nodes_ctx.show(ui_nodes, links, ui);
+        egui::TopBottomPanel::bottom("control_hints").show_inside(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("[MMB] Move canvas");
+                ui.label("[LMB] Move node");
+                ui.label("[LMB] Connect port");
+                ui.label("[ALT]+[LMB] Disconnect port");
+            })
+        });
 
         for (&id, node) in self.nodes.iter_mut() {
             node.position = self.nodes_ctx.get_node_pos_screen_space(id as usize);


### PR DESCRIPTION
Closes #9 

Basic implementation that just statically shows canvas controls at the bottom of the canvas.

I would like to replace the ASCII mouse button and alt key indicators with something more graphical, but while there is no shortage of general keyboard and mouse symbols there don't seem to be any for specific mouse buttons or the alt key. Yes there is ⎇ (U+2387) but I have never actually seen that being used. I expect event the mac equivalent ⌥ (U+2325) to be more widely understood. It seems the best way around this would be to either draw up icons for these and draw them as images among the labels or to craft a custom font that has the symbols in the unicode private use area and use that font for the labels. The font would probably be the better way to handle it since it scales automatically with DPI. I am however not familiar enough with egui so actually figuring out how to implement either solution will take a while. Pointers are welcome.