### PR TITLE
DNF needs to be run with high privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pacman -S pipewire pkg-config clang libxcb
 #### Fedora
 
 ```bash
-dnf install pipewire pipewire-devel clang libxcb-devel
+sudo dnf install pipewire pipewire-devel clang libxcb-devel
 ```
 
 #### Other


### PR DESCRIPTION
dnf needs to be used with elevated privileges, it won't elevate by itself. Normal usage: sudo dnf install pipewire pipewire-devel clang libxcb-devel
And also its cache is different for each user that runs it.