### PR TITLE
Fix window initialization on Wayland

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,9 +1845,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
+checksum = "870427e30b8f2cbe64bf43ec4b86e88fe39b0a84b3f15efd9c9c2d020bc86eb9"
 dependencies = [
  "bitflags 1.3.2",
  "calloop",


### PR DESCRIPTION
Currently, on wayland, the window surface stops receiving updates after the first draw. This is due to a bug in `smithay-client-toolkit` v0.16.0. The fix was introduced in [v0.16.1](https://github.com/Smithay/client-toolkit/compare/v0.16.0...v0.16.1).
