### PR TITLE
bump to pipewire 0.9.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,16 @@ edition = "2021"
 
 
 [dependencies]
-pipewire = "0.8"
+pipewire = "0.9.2"
 rand = "0.8"
-log = {version = "0.4", features = ["release_max_level_warn"] }
+log = { version = "0.4", features = ["release_max_level_warn"] }
 simple_logger = "4"
 natord = "1"
 
 # egui stuff
 eframe = { version = "0.20", features = ["persistence"] }
 egui = "0.20"
-egui_nodes = {git = "https://github.com/Ax9D/egui_nodes", rev="27167e4"}
+egui_nodes = { git = "https://github.com/Ax9D/egui_nodes", rev = "27167e4" }
 serde = { version = "1", features = ["derive"] }
 
 [profile.release]


### PR DESCRIPTION
Not sure if this project is abandoned. 

If so, this PR is based on the current git version and bumps `pipewire` from 0.8.0 to 0.9.2. I focused on getting it running, and did not put any effort on re-writing working parts (even if those might benefit from leveraging the richer type API of 0.9.2).

The PR is minimal, I did not check in the `Cargo.lock` file, so it might be that the current `Cargo.lock` needs to be deleted in order to compile and run.

Let me know if further changes are required to merge.

I do not have a strong feeling if "yet another pwgraph viewer" is called for, but I got a good impression of  the `pw-viz` code base, so it would be a petty if its left hanging. 

/Per 